### PR TITLE
Use nix-data with sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "nix-data"
 version = "0.0.2"
-source = "git+https://github.com/snowflakelinux/nix-data?branch=sqltest#8e9d3bd8a51f92d12e477a7faf3b13054160ec05"
+source = "git+https://github.com/snowflakelinux/nix-data?branch=main#41afc93336877c64e75e4ddd87ae2a043d104782"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +66,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,7 +139,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -118,6 +150,12 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -169,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.13"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
@@ -227,6 +265,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +296,16 @@ checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.12",
 ]
 
 [[package]]
@@ -257,6 +329,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +369,51 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
 ]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -289,12 +438,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "spin",
 ]
 
 [[package]]
@@ -334,6 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -341,6 +509,28 @@ name = "futures-core"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.11.2",
+]
 
 [[package]]
 name = "futures-io"
@@ -368,11 +558,33 @@ checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -418,12 +630,27 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -435,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,7 +675,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -492,7 +725,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -586,6 +819,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +859,27 @@ name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -649,6 +918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,9 +956,10 @@ dependencies = [
 [[package]]
 name = "nix-data"
 version = "0.0.2"
-source = "git+https://github.com/snowflakelinux/nix-data?branch=main#7b936396f4c92e89f8192c197de619a1fc8fb2e8"
+source = "git+https://github.com/snowflakelinux/nix-data?branch=sqltest#8e9d3bd8a51f92d12e477a7faf3b13054160ec05"
 dependencies = [
  "anyhow",
+ "csv",
  "ijson",
  "lazy_static",
  "log",
@@ -692,6 +968,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -700,7 +978,7 @@ version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cc1d93deb37efb27faaf8ffbdf9d0a536a371fb0c1e9dae2bffe01ba55f65a"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.15",
  "nixpkgs-fmt",
  "owo-colors",
  "rnix",
@@ -712,15 +990,15 @@ name = "nix-snow"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "clap 4.0.13",
+ "clap 4.0.15",
  "ijson",
  "lazy_static",
  "nix-data",
  "nix-editor",
  "owo-colors",
  "pretty_env_logger",
- "serde",
- "serde_json",
+ "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -737,6 +1015,16 @@ dependencies = [
  "rowan",
  "serde_json",
  "smol_str",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -825,10 +1113,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -916,6 +1278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +1298,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1037,6 +1416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,7 +1470,7 @@ version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1097,9 +1482,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1110,6 +1515,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol_str"
@@ -1128,6 +1539,120 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
+dependencies = [
+ "itertools",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
+dependencies = [
+ "ahash",
+ "atoi",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "itoa 1.0.4",
+ "libc",
+ "libsqlite3-sys",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "sqlx-rt",
+ "stringprep",
+ "thiserror",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "sqlx-core",
+ "sqlx-rt",
+ "syn",
+ "url",
+]
+
+[[package]]
+name = "sqlx-rt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
+dependencies = [
+ "native-tls",
+ "once_cell",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1260,9 +1785,23 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1272,6 +1811,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1322,6 +1872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,10 +1899,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 clap = "4.0"
-nix-data = { git = "https://github.com/snowflakelinux/nix-data", branch = "sqltest" }
+nix-data = { git = "https://github.com/snowflakelinux/nix-data", branch = "main" }
 owo-colors = { version = "3.5", features = ["supports-colors"] }
 lazy_static = "1.4"
 ijson = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 clap = "4.0"
-nix-data = { git = "https://github.com/snowflakelinux/nix-data", branch = "main" }
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+nix-data = { git = "https://github.com/snowflakelinux/nix-data", branch = "sqltest" }
 owo-colors = { version = "3.5", features = ["supports-colors"] }
 lazy_static = "1.4"
 ijson = "0.1"
 nix-editor = "0.3.0-beta.1"
 pretty_env_logger = "0.4"
+sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "sqlite" ] }
+tokio = { version = "1", features = ["full"] }

--- a/flake.nix
+++ b/flake.nix
@@ -19,24 +19,30 @@
         packages.snow = naersk-lib.buildPackage {
           pname = "snow";
           root = ./.;
+          nativeBuildInputs = with pkgs; [ makeWrapper ];
           buildInputs = with pkgs; [
             openssl
             pkg-config
+            sqlite
           ];
+          postInstall = ''
+            wrapProgram $out/bin/snow --prefix PATH : '${pkgs.lib.makeBinPath [ pkgs.sqlite ]}'
+          '';
         };
 
         defaultPackage = self.packages.${system}.snow;
 
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
-            rust-analyzer
-            rustc
-            rustfmt
             cargo
             cargo-tarpaulin
             clippy
             openssl
             pkg-config
+            rust-analyzer
+            rustc
+            rustfmt
+            sqlite
           ];
         };
       });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-use ijson::IString;
-use serde::{Deserialize, Serialize};
-
 pub mod profile;
 pub mod search;
 pub mod system;
@@ -10,11 +7,4 @@ lazy_static::lazy_static! {
         .bright_purple();
     pub static ref VERSIONSTYLE: owo_colors::Style = owo_colors::Style::new()
         .bright_blue();
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct NixPkg {
-    name: IString,
-    pname: IString,
-    version: IString,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,8 @@ enum Commands {
     },
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     pretty_env_logger::init();
     let cli = Cli::parse();
 
@@ -53,12 +54,12 @@ fn main() {
         Commands::Install { packages, system } => {
             if system {
                 let p: Vec<&str> = packages.iter().map(|x| &**x).collect();
-                if system::install::install(&p).is_err() {
+                if system::install::install(&p).await.is_err() {
                     exit(1)
                 }
             } else {
                 for pkg in packages {
-                    if profile::install::install(&pkg).is_err() {
+                    if profile::install::install(&pkg).await.is_err() {
                         exit(1)
                     }
                 }
@@ -67,12 +68,12 @@ fn main() {
         Commands::Remove { packages, system } => {
             if system {
                 let p: Vec<&str> = packages.iter().map(|x| &**x).collect();
-                if system::remove::remove(&p).is_err() {
+                if system::remove::remove(&p).await.is_err() {
                     exit(1)
                 }
             } else {
                 for pkg in packages {
-                    let _ = profile::remove::remove(&pkg);
+                    let _ = profile::remove::remove(&pkg).await;
                 }
             }
         }
@@ -89,7 +90,7 @@ fn main() {
                         "warning:".if_supports_color(Stdout, |t| t.bright_yellow())
                     );
                 }
-                if system::update::update().is_err() {
+                if system::update::update().await.is_err() {
                     exit(1)
                 }
                 if profile::update::updateall().is_err() {
@@ -103,12 +104,12 @@ fn main() {
                         "warning:".if_supports_color(Stdout, |t| t.bright_yellow())
                     );
                 }
-                if system::update::update().is_err() {
+                if system::update::update().await.is_err() {
                     exit(1)
                 }
             } else if let Some(pkgs) = packages {
                 for pkg in pkgs {
-                    let _ = profile::update::update(&pkg);
+                    let _ = profile::update::update(&pkg).await;
                 }
             } else if profile::update::updateall().is_err() {
                 exit(1)
@@ -150,14 +151,14 @@ fn main() {
                 }
             }
             if profile {
-                let lst = profile::list::list();
+                let lst = profile::list::list().await;
                 printprofilelist(lst);
             } else if system {
-                let lst = nix_snow::system::list::list();
+                let lst = nix_snow::system::list::list().await;
                 printsystemlist(lst);
             } else {
-                let lst = profile::list::list();
-                let syslst = nix_snow::system::list::list();
+                let lst = profile::list::list().await;
+                let syslst = nix_snow::system::list::list().await;
                 println!(
                     "{}",
                     "Profile Packages:".if_supports_color(Stdout, |t| t.bright_cyan())
@@ -177,7 +178,7 @@ fn main() {
                 exit(1);
             }
             let query: Vec<&str> = query.iter().map(|x| &**x).collect();
-            if nix_snow::search::search(&query).is_err() {
+            if nix_snow::search::search(&query).await.is_err() {
                 exit(1)
             };
         }

--- a/src/profile/install.rs
+++ b/src/profile/install.rs
@@ -1,51 +1,99 @@
-use std::{collections::HashMap, fs::File, io::BufReader, process::Command};
+use std::process::Command;
 
 use anyhow::{anyhow, Result};
 use owo_colors::{OwoColorize, Stream::Stdout};
+use sqlx::SqlitePool;
 
-use crate::{NixPkg, PKGSTYLE, VERSIONSTYLE};
+use crate::{PKGSTYLE, VERSIONSTYLE};
 
-pub fn install(pkg: &str) -> Result<()> {
-    let file = nix_data::cache::profile::nixpkgslatest()?;
-    let pkgs: HashMap<String, NixPkg> =
-        serde_json::from_reader(BufReader::new(File::open(file)?)).unwrap();
-    if let Some(p) = pkgs.get(pkg) {
+pub async fn install(pkg: &str) -> Result<()> {
+    let installed = nix_data::cache::profile::getprofilepkgs()?;
+    if installed.contains_key(pkg) {
         println!(
-            "{} {} ({})",
-            "Installing:".if_supports_color(Stdout, |t| t.bright_green()),
+            "{} {}",
             pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
-            p.version
-                .as_str()
-                .if_supports_color(Stdout, |t| t.style(*VERSIONSTYLE)),
+            "is already installed".if_supports_color(Stdout, |t| t.bright_yellow()),
         );
-        let status = Command::new("nix")
-            .arg("profile")
-            .arg("install")
-            .arg("--impure")
-            .arg(&format!("nixpkgs#{}", pkg))
-            .status()?;
-        match status {
-            s if s.success() => {
-                println!(
-                    "{} {} ({})",
-                    "Successfully installed:".if_supports_color(Stdout, |t| t.bright_green()),
-                    pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
-                    p.version
-                        .as_str()
-                        .if_supports_color(Stdout, |t| t.style(*VERSIONSTYLE)),
-                );
-                Ok(())
+        return Ok(());
+    }
+
+    let dbfile = nix_data::cache::profile::nixpkgslatest().await?;
+    let db = format!("sqlite://{}", dbfile);
+    let pool = SqlitePool::connect(&db).await?;
+    let p: Result<(String,), sqlx::Error> =
+        sqlx::query_as("SELECT version FROM pkgs WHERE attribute LIKE $1")
+            .bind(pkg)
+            .fetch_one(&pool)
+            .await;
+    if let Ok((version,)) = p {
+        if version.is_empty() {
+            println!(
+                "{} {}",
+                "Installing:".if_supports_color(Stdout, |t| t.bright_green()),
+                pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE))
+            );
+            let status = Command::new("nix")
+                .arg("profile")
+                .arg("install")
+                .arg("--impure")
+                .arg(&format!("nixpkgs#{}", pkg))
+                .status()?;
+            match status {
+                s if s.success() => {
+                    println!(
+                        "{} {}",
+                        "Successfully installed:".if_supports_color(Stdout, |t| t.bright_green()),
+                        pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE))
+                    );
+                    Ok(())
+                }
+                _ => {
+                    eprintln!(
+                        "{} failed to install {}",
+                        "error:".if_supports_color(Stdout, |t| t.bright_red()),
+                        pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
+                    );
+                    Err(anyhow!("Failed to install {}", pkg))
+                }
             }
-            _ => {
-                eprintln!(
-                    "{} failed to install {} ({})",
-                    "error:".if_supports_color(Stdout, |t| t.bright_red()),
-                    pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
-                    p.version
-                        .as_str()
-                        .if_supports_color(Stdout, |t| t.style(*VERSIONSTYLE)),
-                );
-                Err(anyhow!("Failed to install {}", pkg))
+        } else {
+            println!(
+                "{} {} ({})",
+                "Installing:".if_supports_color(Stdout, |t| t.bright_green()),
+                pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
+                version
+                    .as_str()
+                    .if_supports_color(Stdout, |t| t.style(*VERSIONSTYLE)),
+            );
+            let status = Command::new("nix")
+                .arg("profile")
+                .arg("install")
+                .arg("--impure")
+                .arg(&format!("nixpkgs#{}", pkg))
+                .status()?;
+            match status {
+                s if s.success() => {
+                    println!(
+                        "{} {} ({})",
+                        "Successfully installed:".if_supports_color(Stdout, |t| t.bright_green()),
+                        pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
+                        version
+                            .as_str()
+                            .if_supports_color(Stdout, |t| t.style(*VERSIONSTYLE)),
+                    );
+                    Ok(())
+                }
+                _ => {
+                    eprintln!(
+                        "{} failed to install {} ({})",
+                        "error:".if_supports_color(Stdout, |t| t.bright_red()),
+                        pkg.if_supports_color(Stdout, |t| t.style(*PKGSTYLE)),
+                        version
+                            .as_str()
+                            .if_supports_color(Stdout, |t| t.style(*VERSIONSTYLE)),
+                    );
+                    Err(anyhow!("Failed to install {}", pkg))
+                }
             }
         }
     } else {

--- a/src/profile/list.rs
+++ b/src/profile/list.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
-pub fn list() -> Result<HashMap<String, String>> {
-    let currpkgs = nix_data::cache::profile::getprofilepkgs_versioned()?;
+pub async fn list() -> Result<HashMap<String, String>> {
+    let currpkgs = nix_data::cache::profile::getprofilepkgs_versioned().await?;
     let allpkgs = nix_data::cache::profile::getprofilepkgs()?;
     let mut list = HashMap::new();
     for (pkg, prof) in allpkgs {

--- a/src/profile/remove.rs
+++ b/src/profile/remove.rs
@@ -5,9 +5,9 @@ use owo_colors::{OwoColorize, Stream::Stdout};
 
 use crate::{PKGSTYLE, VERSIONSTYLE};
 
-pub fn remove(pkg: &str) -> Result<()> {
-    let pkgs = nix_data::cache::profile::getprofilepkgs()?;
-    let currpkgs = nix_data::cache::profile::getprofilepkgs_versioned()?;
+pub async fn remove(pkg: &str) -> Result<()> {
+    let pkgs = nix_data::cache::profile::getprofilepkgs().unwrap();
+    let currpkgs = nix_data::cache::profile::getprofilepkgs_versioned().await.unwrap();
     if let Some(version) = currpkgs.get(pkg) {
         println!(
             "{} {} ({})",
@@ -48,7 +48,7 @@ pub fn remove(pkg: &str) -> Result<()> {
                 Err(anyhow!("Failed to remove {}", pkg))
             }
         }
-    } else if pkgs.contains_key(pkg) {
+    } else if pkgs.get(pkg).map(|x| x.originalurl.to_string()) == Some(String::from("flake:nixpkgs")) {
         println!(
             "{} {}",
             "Removing:".if_supports_color(Stdout, |t| t.bright_green()),

--- a/src/system/list.rs
+++ b/src/system/list.rs
@@ -2,10 +2,10 @@ use std::{collections::HashMap, fs};
 
 use anyhow::{Context, Result};
 
-pub fn list() -> Result<HashMap<String, Option<String>>> {
+pub async fn list() -> Result<HashMap<String, Option<String>>> {
     let config = nix_data::config::configfile::getconfig()?;
     let configfile = config.systemconfig.context("Failed to get config file")?;
-    let currpkgs = nix_data::cache::flakes::getflakepkgs(&[&configfile])?;
+    let currpkgs = nix_data::cache::flakes::getflakepkgs(&[&configfile]).await?;
     let allpkgs = nix_editor::read::getarrvals(
         &fs::read_to_string(configfile)?,
         "environment.systemPackages",

--- a/src/system/update.rs
+++ b/src/system/update.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use anyhow::{anyhow, Context, Result};
 use owo_colors::{OwoColorize, Stream::Stdout};
 
-pub fn update() -> Result<()> {
+pub async fn update() -> Result<()> {
     println!(
         "{}",
         "Updating".if_supports_color(Stdout, |t| t.bright_green())


### PR DESCRIPTION
Using SQLite to cache package data speeds up most transactions by removing the need to load the entire `packages.json` file.