### PR TITLE
MacOS fix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,9 +18,9 @@ pkgs.rustPlatform.buildRustPackage {
     makeWrapper
     pkg-config
   ];
-  buildInputs = with pkgs; [
+  buildInputs = (with pkgs; [
     openssl
-  ];
+  ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ darwin.apple_sdk.frameworks.Security ]);
 
   doCheck = false;
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         defaultApp = apps.${name};
 
         devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [
+          buildInputs = (with pkgs; [
             cargo
             cargo-tarpaulin
             clippy
@@ -36,7 +36,7 @@
             rustc
             rustfmt
             sqlite
-          ];
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ darwin.apple_sdk.frameworks.Security libiconv ]);
         };
       });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 pub mod profile;
 pub mod search;
 pub mod system;
@@ -11,6 +13,8 @@ lazy_static::lazy_static! {
     pub static ref ERRORSTYLE: owo_colors::Style = owo_colors::Style::new()
         .bright_red()
         .bold();
-    pub static ref SYSTEM: String = std::fs::read_to_string("/run/current-system/system")
-        .unwrap_or_else(|_| "x86_64-linux".to_string());
+    pub static ref SYSTEM: String = String::from_utf8_lossy(&Command::new("nix")
+        .args(["eval", "--impure", "--raw", "--expr", "builtins.currentSystem"])
+        .output()
+        .expect("Failed to get current system").stdout).to_string();
 }


### PR DESCRIPTION
Add required dependencies for building on MacOS.
Use builtins.currentSystem instead of /run/current-system/system to get system since that directory doesn't exists on MacOS and may not exist on other systems as well.

